### PR TITLE
return proper context format and initial stack walking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,15 +7,22 @@ use regex::Regex;
 
 #[pyfunction]
 #[pyo3(text_signature = "(s)")]
-fn read_lines_from_file(path: &str, lineno: usize, context_lines: usize) -> Vec<String> {
-    let reader = io::BufReader::new(File::open(path).expect("Cannot open file"));
+fn read_lines_from_file(path: &str, lineno: usize, context_lines: usize) -> (Vec<String>, String, Vec<String>) {
     let start = cmp::max(0, lineno - context_lines);
-    let lines_iter = reader.lines().skip(start).take(context_lines * 2 + 1).map(|l| l.unwrap());
-    let mut lines = Vec::<String>::new();
-    for line in lines_iter {
-        lines.push(line.to_string())
+    let pre_context = get_lines(path, start, context_lines);
+    let main_line = get_lines(path, (start + context_lines), 1).first().unwrap().to_string();
+    let post_context = get_lines(path, (start + context_lines + 1), context_lines);
+    (pre_context, main_line, post_context)
+}
+
+fn get_lines(path: &str, skip:usize, count: usize) -> Vec<String> {
+    let reader = io::BufReader::new(File::open(path).expect("Cannot open file"));
+    let lines = reader.lines().skip(skip).take(count).map(|l| l.unwrap());
+    let mut values = Vec::<String>::new();
+    for line in lines {
+        values.push(line.to_string())
     }
-    lines
+    values
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,17 @@ fn get_lines(path: &str, skip:usize, count: usize) -> Vec<String> {
     values
 }
 
-
+#[pyfunction]
+fn walk_stack(frame: &PyAny) -> Vec<&PyAny> {
+    let mut frames = Vec::<&PyAny>::new();
+    let mut current_frame: &PyAny = frame;
+    frames.push(current_frame);
+    while current_frame.hasattr("f_back").unwrap() {
+        frames.push(current_frame);
+        current_frame = current_frame.getattr("f_back").unwrap()
+    }
+    frames
+}
 
 fn is_library_frame(absolute_path: String, include_paths: Vec<String>, exclude_paths: Vec<String>) -> bool {
     if (!include_paths.is_empty()) && get_path_regex(include_paths).is_match(&absolute_path) {
@@ -47,5 +57,6 @@ fn get_path_regex(paths: Vec<String>) -> Regex {
 #[pymodule]
 fn elasticapmspeedups(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_lines_from_file, m)?)?;
+    m.add_function(wrap_pyfunction!(walk_stack, m)?)?;
     Ok(())
 }

--- a/test.py
+++ b/test.py
@@ -1,3 +1,7 @@
 import elasticapmspeedups
+import inspect
 # should output lines 9 through 13 to stdout
 print(elasticapmspeedups.read_lines_from_file('input', 10, 2))
+
+# should print a list of dicts of frame info
+print(elasticapmspeedups.walk_stack(inspect.currentframe()))

--- a/test.py
+++ b/test.py
@@ -5,3 +5,5 @@ print(elasticapmspeedups.read_lines_from_file('input', 10, 2))
 
 # should print a list of dicts of frame info
 print(elasticapmspeedups.walk_stack(inspect.currentframe()))
+locals = getattr(inspect.currentframe(), "f_locals", {})
+print(elasticapmspeedups.dictate(locals))


### PR DESCRIPTION
([pre_context...], line, [post_context...]) as is the proper format.

Could probably be optimized to peel off `context_lines * 2 + 1` from a single buffered reader, which would be more performant.

Also adds the ability to walk (but not yet Mess With™) frames in Rust using PyAny objects. This is probably not much faster than doing it in python, but if we can retrieve the frames, we can also Dictate™ the local variables and return the Dicts.